### PR TITLE
requirements.txt を追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4==4.6.0
+numpy==1.14.3
+pandas==0.23.0
+Faker==0.8.17


### PR DESCRIPTION
pip でのライブラリインストールを一括で行うために requiremens.txt を追加.
以後, インストールできていないモジュールは,
`pip install -r requirements.txt`
でインストールする.

ライブラリを追加インストールした場合は requirements.txt に追記する.